### PR TITLE
refactor: switch Opine into Serve (STD)

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -14,6 +14,6 @@ export { Url } from "https://cdn.skypack.dev/reurl";
 
 export { DOMParser, Element } from "https://deno.land/x/deno_dom/deno-dom-wasm.ts";
 
-export { opine, json } from "https://deno.land/x/opine@2.0.0/mod.ts";
-
 export { assertEquals } from "https://deno.land/std@0.117.0/testing/asserts.ts";
+
+export { serve } from "https://deno.land/std@0.117.0/http/server.ts"


### PR DESCRIPTION
Because of Playground only need small of attention and method so we want it minimize us much as possible. Enjoy minimum dependency. 