### PR TITLE
feat: using GraphQL Deno module, Trim, and Better Typescript Support 

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -7,8 +7,14 @@ export {
   GraphQLObjectType,
   GraphQLNonNull,
   GraphQLInterfaceType,
-  GraphQLList
-} from "https://cdn.skypack.dev/graphql@^16.0.0";
+  GraphQLList,
+} from "https://deno.land/x/graphql_deno@v15.0.0/mod.ts";
+
+export type {
+  GraphQLObjectTypeConfig,
+  GraphQLInterfaceTypeConfig,
+  GraphQLFieldConfigMap
+} from "https://deno.land/x/graphql_deno@v15.0.0/mod.ts";
 
 export { Url } from "https://cdn.skypack.dev/reurl";
 

--- a/schema.ts
+++ b/schema.ts
@@ -24,6 +24,7 @@ type TParams = {
   name?: string
   url?: string
   source?: string
+  trim?: boolean
 }
 
 function getAttributeOfElement(element: Element, name: string) {
@@ -63,11 +64,20 @@ function sharedFields(): GraphQLFieldConfigMap<Element, any> {
     text: {
       type: GraphQLString,
       description: 'The text content of the selected DOM node',
-      args: { selector },
-      resolve(element: Element, { selector }: TParams) {
+      args: {
+        selector,
+        trim: {
+          type: GraphQLBoolean,
+          description: "Optional text trim. default: false",
+          defaultValue: false
+        }
+      },
+      resolve(element: Element, { selector, trim }: TParams) {
         element = selector ? element.querySelector(selector)! : element
 
-        return element && element.textContent
+        const result = element && element.textContent
+
+        return (trim) ? result.trim() : result;
       },
     },
     tag: {

--- a/server.ts
+++ b/server.ts
@@ -3,7 +3,7 @@ import { useQuery } from './schema.ts'
 
 import { prismqlPlayground } from "./web.ts"
 
-export function createServer(port: string | number) {
+export function createServer(port: string | number = 8080) {
   async function handler(req: Request): Promise<Response> {
     switch (req.method) {
       case "GET": {


### PR DESCRIPTION
## Change Log
- Refactor: using [graphql_deno](https://deno.land/x/graphql_deno) module.
- Better typescript support for schema and return value (no Promise<any>).
- New feature optional `trim` on text field
- Fix default port on `createServer`

![image](https://user-images.githubusercontent.com/24630806/146397757-e381cabd-d90d-4930-86d4-906e7c445c36.png)
